### PR TITLE
[EDU-1150] - Promises not explicitly required

### DIFF
--- a/promises/node.js
+++ b/promises/node.js
@@ -1,5 +1,4 @@
-// Include the promises interface
-const Ably = require("ably/promises");
+const Ably = require("ably");
 // Create the client
 const ably = new Ably.Realtime.Promise({
   authUrl: "https://ably.com/ably-auth/token/docs",


### PR DESCRIPTION
## Description

Small change. You can just require `ably`, but specify promises interface when creating the client.

* [EDU-1150](https://ably.atlassian.net/browse/EDU-1150)